### PR TITLE
Only reset selected day or month if necessary

### DIFF
--- a/src/dropdown-datepicker.vue
+++ b/src/dropdown-datepicker.vue
@@ -361,9 +361,16 @@ export default {
       this.year = value;
       this.populateMonth();
       this.populateDay();
-      this.month = null;
-      this.day = null;
-    //   console.log(this.year, this.month, this.day);
+
+      if (this.months.indexOf(this.month) < 0) {
+          this.month = null;
+      }
+
+      if (this.days.indexOf(this.day) < 0) {
+          this.day = null;
+      }
+
+      //   console.log(this.year, this.month, this.day);
       if(this.onYearChange != null){
         this.onYearChange(value);
       }
@@ -371,8 +378,10 @@ export default {
     },
     monthChangeCallback(value) {
       this.month = value;
-      this.day = null;
       this.populateDay();
+      if (this.days.indexOf(this.day) < 0) {
+          this.day = null;
+      }
       if(this.onMonthChange != null){
         this.onMonthChange(value);
       }

--- a/src/dropdown-datepicker.vue
+++ b/src/dropdown-datepicker.vue
@@ -412,15 +412,15 @@ export default {
     },
     dayChangeCallback(value){
       this.day = value;
-      if(this.day != 0 && this.month != 0 && this.year != 0 && this.submitId != ''){
-        document.getElementById(this.submitId).value = this.formatSubmitDate(this.day, this.month, this.year);
-      }
       if(this.onDayChange != null){
         this.onDayChange(value);
       }
       this.changeCallback();
     },
     changeCallback(){
+        if(this.day != null && this.month != null && this.year != null && this.submitId != ''){
+          document.getElementById(this.submitId).value = this.formatSubmitDate(this.day, this.month, this.year);
+        }
         if(this.onChange != null){
             this.onChange(this.day, this.month, this.year);
         }


### PR DESCRIPTION
This is a change to only reset the day or month if necessary when the year or month is changed. Instead of always resetting the day or month, check if the currently selected day or month is valid. If it's valid, keep the current selection, otherwise reset like before. This also includes a change to update the submit id element on any change not just on a day change.